### PR TITLE
Django/djangorestframework upgrade

### DIFF
--- a/app/openlxp_xms_project/settings.py
+++ b/app/openlxp_xms_project/settings.py
@@ -166,8 +166,9 @@ EMAIL_BACKEND = "django_ses.SESBackend"
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
+
 CSRF_COOKIE_DOMAIN = '.deloitteopenlxp.com'
-CSRF_TRUSTED_ORIGINS = ['.deloitteopenlxp.com', ]
+CSRF_TRUSTED_ORIGINS = ['https://dev-xms-admin.deloitteopenlxp.com', 'http://localhost:8000', ]
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 

--- a/app/openlxp_xms_project/settings.py
+++ b/app/openlxp_xms_project/settings.py
@@ -168,7 +168,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
 
 CSRF_COOKIE_DOMAIN = '.deloitteopenlxp.com'
-CSRF_TRUSTED_ORIGINS = ['https://dev-xms-admin.deloitteopenlxp.com', 'http://localhost:8000', ]
+CSRF_TRUSTED_ORIGINS = ['https://dev-xms-admin.deloitteopenlxp.com', ]
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 

--- a/app/openlxp_xms_project/urls.py
+++ b/app/openlxp_xms_project/urls.py
@@ -14,16 +14,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path
+from django.urls import re_path
 from django.urls.conf import include
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path('api/', include('api.urls')),
-    path("api/", include("users.urls")),
-    path("api/", include("configurations.urls")),
-    url("", include("openlxp_authentication.urls")),
+    re_path("admin/", admin.site.urls),
+    re_path('api/', include('api.urls')),
+    re_path("api/", include("users.urls")),
+    re_path("api/", include("configurations.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,51 +1,51 @@
-mysql-connector-python >= 8.0.28, <=8.0.29
-
-django-mysql>=3.10.0,<3.11.0
-
-Django>=3.1.4,<3.2.0
-
-djangorestframework>=3.12.2,<3.13.0
-
 boto3~=1.16.54
 
-flake8>=3.8.4,<3.9.0
-
-gunicorn>=20.0.4,<20.1.0
-
-isort==5.11.5
-
-martor>=1.5.8,<1.6.0
-
-pandas>=1.1.5,<1.2.0
-
-fsspec>=0.8.5,<0.9.0
-
-numpy>= 1.19.5, < 1.20.0
-
-s3fs
+boto3~=1.16.54
 
 coverage>=5.5,<6.0
 
-boto3~=1.16.54
+ddt>=1.4.2, <1.5.0
 
-django-ses>=2.0.0 , <2.1.0
+django-admin-interface>=0.28.3
+
+django-colorfield>=0.11.0
 
 django-cors-headers>=3.7.0, <3.8.0
 
 django-model-utils>=4.1.1,<4.2.0
 
-ddt>=1.4.2, <1.5.0
+django-mysql==4.4.0
 
-requests>=2.25.1, <2.26.0
+django-ses~=3.5.0
 
-openlxp-authentication >=1.1.0, <1.2
- 
-django-admin-interface>=0.28.3
- 
-django-colorfield>=0.11.0
- 
+Django>=4.2,<5.0
+
+djangorestframework>=3.15.2,<3.16.0
+
+flake8>=3.8.4,<3.9.0
+
+fsspec>=0.8.5,<0.9.0
+
+gunicorn>=22.0.0, <22.1.0
+
+isort==5.11.5
+
+martor>=1.5.8,<1.6.0
+
+mysql-connector-python >= 8.0.28, <=8.0.29
+
+numpy==1.26.4
+
+openlxp-authentication >=1.1.2, <1.2
+
+pandas>=1.3.5,<1.4.0
+
+Pillow>=10.3.0, <10.4.0
+
 python-slugify>=8.0.1
- 
-text-unidecode>=1.3
 
-Pillow>=10.2.0
+requests~=2.32.2
+
+s3fs
+
+text-unidecode>=1.3


### PR DESCRIPTION
- Django upgraded to 4.2 due to djangorestframework needing an upgrade to 3.15.2. 
- urls.py needed modifications due to django being upgraded from 3.x to 4.x
- CSRF_TRUSTED_ORIGINS requires http/https 